### PR TITLE
Added app principal authentication

### DIFF
--- a/lib/auth/authentication-context.js
+++ b/lib/auth/authentication-context.js
@@ -6,7 +6,8 @@
     urlparse = require('url').parse,
     parseXml = require('../xml-parser.js').parseXml,
     response = require('../request-utilities.js').response,
-    request = require('../request-utilities.js').request;
+    request = require('../request-utilities.js').request,
+    XMLHttpRequest = require("xmlhttprequest").XMLHttpRequest;
 
 
 
@@ -53,8 +54,12 @@ function setAuthenticationCookie(clientContext) {
     var self = this;
     clientContext.add_executingWebRequest(function (sender, e) {
         var headers = e.get_webRequest().get_headers();
-        var authCookie = 'FedAuth=' + self.FedAuth + '; rtFa=' + self.rtFa;
-        headers['Cookie'] = authCookie;
+        if (self.FedAuth) {
+            var authCookie = 'FedAuth=' + self.FedAuth + '; rtFa=' + self.rtFa;
+            headers['Cookie'] = authCookie;
+        } else {
+            headers['Authorization'] = "Bearer " + self.appAccessToken;
+        }
     });
 }
 
@@ -103,6 +108,73 @@ function acquireTokenForUser(username, password, callback) {
     });
 }
 
+function acquireTokenForApp(clientId, clientSecret, callback) {
+    var self = this;
+    
+    getRealm(self, (err, realm) => {
+        if (err) {
+            callback(err);
+            return;
+        }
+
+        authenticateApp(self, realm, clientId, clientSecret, (err, access_token) => {
+            if (err) {
+                callback(err);
+                return;
+            }
+
+            self.appAccessToken = access_token;
+            callback(null, {});
+        });
+    });
+}
+
+function getRealm(self, callback) {
+    ajaxPost(self.url.href + "_vti_bin/client.svc", { "Authorization": "Bearer " }, "").then(xmlhttp => {
+        var wwwAuthHeader = xmlhttp.getResponseHeader("WWW-Authenticate");
+        if (!wwwAuthHeader)
+            callback("Error retrieving realm: " + xmlhttp.responseText, null);
+        else {
+            var realm = wwwAuthHeader.split(",")[0].split("=")[1].slice(1, -1);
+            callback(null, realm);
+        }
+    });
+}
+
+function authenticateApp(self, realm, clientId, clientSecret, callback) {
+    var oauthUrl = "https://accounts.accesscontrol.windows.net/" + realm + "/tokens/OAuth/2";
+    var redirecturi = "https://localhost"
+    var appResource = "00000003-0000-0ff1-ce00-000000000000"
+
+    var body = "grant_type=client_credentials";
+    body += "&client_id=" + clientId + "@" + realm;
+    body += "&client_secret=" + clientSecret;
+    body += "&redirect_uri=" + redirecturi;
+    body += "&resource=" + appResource + "/" + self.url.hostname + "@" + realm;
+
+    var headers = { "Content-Type": "application/x-www-form-urlencoded" };
+
+    ajaxPost(oauthUrl, headers, body).then(xmlhttp => {
+        var access_token = JSON.parse(xmlhttp.responseText).access_token;
+        callback(access_token ? null : xmlhttp.responseText, access_token)
+    });
+}
+
+function ajaxPost(url, headers, body) {
+    return new Promise((resolve, reject) => {
+        var xmlhttp = new XMLHttpRequest();
+        xmlhttp.onreadystatechange = function() {
+            if (xmlhttp.readyState == 4 ) {
+                resolve(xmlhttp);
+            }
+        };
+        xmlhttp.open("POST", url, true);
+        for (var k in headers)
+            xmlhttp.setRequestHeader(k, headers[k]);
+        xmlhttp.send(body);
+    });
+}
+
 
 function requestFormDigest(username, password, callback) {
     throw new Error('requestFormDigest function is not implemented');
@@ -138,6 +210,7 @@ AuthenticationContext = function (url) {
 
 AuthenticationContext.prototype = {
     acquireTokenForUser: acquireTokenForUser,
+    acquireTokenForApp: acquireTokenForApp,
     setAuthenticationCookie: setAuthenticationCookie, 
     requestFormDigest : requestFormDigest
 };


### PR DESCRIPTION
Now it's possible to authenticate with SharePoint app principals credentials (client id & client secret). 

App should be created using `/_layouts/15/appregnew.aspx` and then appropriate permissions should be assigned using `/_layouts/15/appinv.aspx`.

Usage example:

```javascript
var csomapi = require("csom-node");
 
var settings = {
    url: "https://contoso.sharepoint.com/",
    clientId: "YOUR-GUID-GOES-HERE",
    clientSecret: "YOUR-CLIENT-SECRET-GOES-HERE"
};
 
csomapi.setLoaderOptions({url: settings.url});  //set CSOM library settings
 
var authCtx = new AuthenticationContext(settings.url);
authCtx.acquireTokenForApp(settings.clientId, settings.clientSecret, function (err, data) {
    
    var ctx = new SP.ClientContext("/");  //set root web
    authCtx.setAuthenticationCookie(ctx);  //authenticate
    
    //retrieve SP.Web client object
    var web = ctx.get_web();
    ctx.load(web);
    ctx.executeQueryAsync(function () {
        console.log(web.get_title());
    },
    function (sender, args) {
        console.log('An error occured: ' + args.get_message());
    });
      
});
```