### PR TITLE
webpack compatibility fix

### DIFF
--- a/lib/csom-loader.js
+++ b/lib/csom-loader.js
@@ -37,7 +37,7 @@ var Loader = {
         packages.forEach(function (packageName) {
             Settings.packages[packageName].forEach(function(file) {
                 var filePath = self.resolvePath(self.LocalServerSettings.path, file);
-                var spm = require(filePath);
+                var spm = eval('require')(filePath);
                 //console.log("Module " + filePath + " has been loaded successfully..");
             });
         });


### PR DESCRIPTION
When bundling csom-node with webpack, it tries to replace all `require`-s, but fails on this one (see the diff) because it uses a dynamic variable.

There is a possibility to still use dynamic require as described [here](https://webpack.github.io/docs/context.html#dynamic-require-rewriting) - in this case webpack will try to bundle all SharePoint modules into same bundle as well, but the problem with this is that somewhere in SharePoint modules there are also dynamic requires and webpack then fails on them, resulting in critical dependencies situation.

So the most practical solution that I found is to replace `require` to `eval('require')` and then copy SharePoint modules unmodified to the build folder using e.g. copy-webpack-plugin. I understand that this looks a bit ugly, but I spent several hours trying to find a better solution and unfortunately haven't found anything adequate.

I ask to accept this PR only as a temporary solution until a better solution is found.

Note: bundling is **unavoidable** in Azure Functions environment, using unbundled version results in critical performance issues (Function startup time is >10 seconds).