### PR TITLE
Fix for acquireTokenForApp returning 404 file not found if url has no trailing slash at end

### DIFF
--- a/lib/auth/authentication-context.js
+++ b/lib/auth/authentication-context.js
@@ -143,7 +143,7 @@ function getRealm(self, callback) {
             callback(null, realm);
         }
     });
-}*/
+}
 
 function authenticateApp(self, realm, clientId, clientSecret, callback) {
     var oauthUrl = "https://accounts.accesscontrol.windows.net/" + realm + "/tokens/OAuth/2";

--- a/lib/auth/authentication-context.js
+++ b/lib/auth/authentication-context.js
@@ -130,7 +130,11 @@ function acquireTokenForApp(clientId, clientSecret, callback) {
 }
 
 function getRealm(self, callback) {
-    ajaxPost(self.url.href + "_vti_bin/client.svc", { "Authorization": "Bearer " }, "").then(xmlhttp => {
+    
+    //ajaxPost(self.url.href + "_vti_bin/client.svc", { "Authorization": "Bearer " }, "").then(xmlhttp => {
+    //added slash before '_vtin_bin' as if url does not contains trailing slash, url was forming incorrect 
+    //and it was returing 404 file not found
+    ajaxPost(self.url.href + "/_vti_bin/client.svc", { "Authorization": "Bearer " }, "").then(xmlhttp => {
         var wwwAuthHeader = xmlhttp.getResponseHeader("WWW-Authenticate");
         if (!wwwAuthHeader)
             callback("Error retrieving realm: " + xmlhttp.responseText, null);
@@ -139,7 +143,7 @@ function getRealm(self, callback) {
             callback(null, realm);
         }
     });
-}
+}*/
 
 function authenticateApp(self, realm, clientId, clientSecret, callback) {
     var oauthUrl = "https://accounts.accesscontrol.windows.net/" + realm + "/tokens/OAuth/2";


### PR DESCRIPTION
authCtx.acquireTokenForApp method was returning 404 FILE NOT FOUND when url does not contain '/' at the end.

Method changed getrealm, just added slash before '_vti_bin' and added comments for same